### PR TITLE
getdents: account for d_name size in tst_dirp_size

### DIFF
--- a/testcases/kernel/syscalls/getdents/getdents.h
+++ b/testcases/kernel/syscalls/getdents/getdents.h
@@ -64,9 +64,9 @@ tst_dirp_size(void)
 {
 	switch (tst_variant) {
 	case 0:
-		return sizeof(struct linux_dirent);
+		return sizeof(struct linux_dirent) + NAME_MAX;
 	case 1:
-		return sizeof(struct linux_dirent64);
+		return sizeof(struct linux_dirent64) + NAME_MAX;
 #if HAVE_GETDENTS
 	case 2:
 		return sizeof(struct dirent);


### PR DESCRIPTION
The linux_dirent and linux_dirent64 structs do not contain space for the d_name member.  Add NAME_MAX to the size in tst_dirp_size so that the getdents syscalls do not spuriously fail with EINVAL instead of EFAULT.


Acked-by: Jan Stancek <jstancek@redhat.com>
